### PR TITLE
feat: discord webhooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,13 +27,14 @@
 		"@types/node": "^22.10.5",
 		"@types/pg": "^8.11.10",
 		"autoprefixer": "^10.4.20",
-		"bits-ui": "1.0.0-next.81",
+		"bits-ui": "1.0.0-next.85",
 		"clsx": "^2.1.1",
 		"drizzle-kit": "^0.30.1",
 		"embla-carousel-svelte": "^8.5.2",
 		"eslint": "^9.7.0",
 		"eslint-config-prettier": "^9.1.0",
 		"eslint-plugin-svelte": "^2.36.0",
+		"formsnap": "^2.0.0",
 		"globals": "^15.0.0",
 		"lucide-svelte": "^0.469.0",
 		"mode-watcher": "^0.5.0",
@@ -43,6 +44,7 @@
 		"svelte": "^5.0.0",
 		"svelte-check": "^4.0.0",
 		"svelte-sonner": "^0.3.28",
+		"sveltekit-superforms": "^2.22.1",
 		"tailwind-merge": "^2.6.0",
 		"tailwind-variants": "^0.3.0",
 		"tailwindcss": "^3.4.9",
@@ -51,7 +53,8 @@
 		"typescript": "^5.0.0",
 		"typescript-eslint": "^8.0.0",
 		"vaul-svelte": "1.0.0-next.3",
-		"vite": "^5.4.11"
+		"vite": "^5.4.11",
+		"zod": "^3.24.1"
 	},
 	"dependencies": {
 		"@libsql/client": "^0.9.0",
@@ -73,8 +76,6 @@
 		"jsonwebtoken": "^9.0.2",
 		"layerchart": "^0.91.1",
 		"nanoid": "^5.0.9",
-		"pg": "^8.13.1",
-		"sveltekit-superforms": "^2.22.1",
-		"zod": "^3.24.1"
+		"pg": "^8.13.1"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,12 +68,6 @@ importers:
       pg:
         specifier: ^8.13.1
         version: 8.13.1
-      sveltekit-superforms:
-        specifier: ^2.22.1
-        version: 2.22.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.16.1)(vite@5.4.11(@types/node@22.10.5)))(svelte@5.16.1)(vite@5.4.11(@types/node@22.10.5)))(@types/json-schema@7.0.15)(svelte@5.16.1)(typescript@5.7.2)
-      zod:
-        specifier: ^3.24.1
-        version: 3.24.1
     devDependencies:
       '@eslint/compat':
         specifier: ^1.2.3
@@ -103,8 +97,8 @@ importers:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.49)
       bits-ui:
-        specifier: 1.0.0-next.81
-        version: 1.0.0-next.81(svelte@5.16.1)
+        specifier: 1.0.0-next.85
+        version: 1.0.0-next.85(svelte@5.16.1)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -123,6 +117,9 @@ importers:
       eslint-plugin-svelte:
         specifier: ^2.36.0
         version: 2.46.1(eslint@9.17.0(jiti@1.21.7))(svelte@5.16.1)
+      formsnap:
+        specifier: ^2.0.0
+        version: 2.0.0(svelte@5.16.1)(sveltekit-superforms@2.22.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.16.1)(vite@5.4.11(@types/node@22.10.5)))(svelte@5.16.1)(vite@5.4.11(@types/node@22.10.5)))(@types/json-schema@7.0.15)(svelte@5.16.1)(typescript@5.7.2))
       globals:
         specifier: ^15.0.0
         version: 15.14.0
@@ -150,6 +147,9 @@ importers:
       svelte-sonner:
         specifier: ^0.3.28
         version: 0.3.28(svelte@5.16.1)
+      sveltekit-superforms:
+        specifier: ^2.22.1
+        version: 2.22.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.16.1)(vite@5.4.11(@types/node@22.10.5)))(svelte@5.16.1)(vite@5.4.11(@types/node@22.10.5)))(@types/json-schema@7.0.15)(svelte@5.16.1)(typescript@5.7.2)
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.0
@@ -177,6 +177,9 @@ importers:
       vite:
         specifier: ^5.4.11
         version: 5.4.11(@types/node@22.10.5)
+      zod:
+        specifier: ^3.24.1
+        version: 3.24.1
 
 packages:
 
@@ -1360,8 +1363,8 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  bits-ui@1.0.0-next.81:
-    resolution: {integrity: sha512-LSvKvlPdDqBnRXKc2M/YyibR8d7XIvrZbgDxtevmCLcYxuIrFMBGir9uYPohPIUQcLterc/MdLNlG4glpCzNvg==}
+  bits-ui@1.0.0-next.85:
+    resolution: {integrity: sha512-rRImjgbc87eoNnBFPGpuwH4cq8enSrZTVuku1qj4fNW1OIL6XP/jqiAcg4LXIGjo6gpaM4x6uHqxlIwFHsegdg==}
     engines: {node: '>=18', pnpm: '>=8.7.0'}
     peerDependencies:
       svelte: ^5.11.0
@@ -1951,6 +1954,13 @@ packages:
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
+
+  formsnap@2.0.0:
+    resolution: {integrity: sha512-W61elddvdzeBEs10nNvwxQnx/FctJFHBXPk9uluNQAckHo1nuSUvSQGIjtLjTKIbQdQnwEOoxqWrk9tuv0U7hA==}
+    engines: {node: '>=18', pnpm: '>=8.7.0'}
+    peerDependencies:
+      svelte: ^5.0.0
+      sveltekit-superforms: ^2.19.0
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
@@ -2641,11 +2651,6 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
-  runed@0.20.0:
-    resolution: {integrity: sha512-YqPxaUdWL5nUXuSF+/v8a+NkVN8TGyEGbQwTA25fLY35MR/2bvZ1c6sCbudoo1kT4CAJPh4kUkcgGVxW127WKw==}
-    peerDependencies:
-      svelte: ^5.7.0
-
   runed@0.23.2:
     resolution: {integrity: sha512-AhHCb5/B+YQW6ar1pzhGQOQy+byfjCH63ofuhrexSWwQKhC0EbQ60Z/wMYwETLo3ZubhwlNryxBt0seOMOrVFQ==}
     peerDependencies:
@@ -2781,8 +2786,14 @@ packages:
     peerDependencies:
       svelte: ^5.0.0-next.126
 
-  svelte-toolbelt@0.7.0:
-    resolution: {integrity: sha512-i/Tv4NwAWWqJnK5H0F8y/ubDnogDYlwwyzKhrspTUFzrFuGnYshqd2g4/R43ds841wmaFiSW/HsdsdWhPOlrAA==}
+  svelte-toolbelt@0.5.0:
+    resolution: {integrity: sha512-t3tenZcnfQoIeRuQf/jBU7bvTeT3TGkcEE+1EUr5orp0lR7NEpprflpuie3x9Dn0W9nOKqs3HwKGJeeN5Ok1sQ==}
+    engines: {node: '>=18', pnpm: '>=8.7.0'}
+    peerDependencies:
+      svelte: ^5.0.0-next.126
+
+  svelte-toolbelt@0.7.1:
+    resolution: {integrity: sha512-HcBOcR17Vx9bjaOceUvxkY3nGmbBmCBBbuWLLEWO6jtmWH8f/QoWmbyUfQZrpDINH39en1b8mptfPQT9VKQ1xQ==}
     engines: {node: '>=18', pnpm: '>=8.7.0'}
     peerDependencies:
       svelte: ^5.0.0
@@ -3990,7 +4001,7 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  bits-ui@1.0.0-next.81(svelte@5.16.1):
+  bits-ui@1.0.0-next.85(svelte@5.16.1):
     dependencies:
       '@floating-ui/core': 1.6.8
       '@floating-ui/dom': 1.6.12
@@ -3998,7 +4009,7 @@ snapshots:
       esm-env: 1.2.1
       runed: 0.23.2(svelte@5.16.1)
       svelte: 5.16.1
-      svelte-toolbelt: 0.7.0(svelte@5.16.1)
+      svelte-toolbelt: 0.7.1(svelte@5.16.1)
 
   brace-expansion@1.1.11:
     dependencies:
@@ -4586,6 +4597,12 @@ snapshots:
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
+
+  formsnap@2.0.0(svelte@5.16.1)(sveltekit-superforms@2.22.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.16.1)(vite@5.4.11(@types/node@22.10.5)))(svelte@5.16.1)(vite@5.4.11(@types/node@22.10.5)))(@types/json-schema@7.0.15)(svelte@5.16.1)(typescript@5.7.2)):
+    dependencies:
+      svelte: 5.16.1
+      svelte-toolbelt: 0.5.0(svelte@5.16.1)
+      sveltekit-superforms: 2.22.1(@sveltejs/kit@2.15.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.16.1)(vite@5.4.11(@types/node@22.10.5)))(svelte@5.16.1)(vite@5.4.11(@types/node@22.10.5)))(@types/json-schema@7.0.15)(svelte@5.16.1)(typescript@5.7.2)
 
   fraction.js@4.3.7: {}
 
@@ -5197,11 +5214,6 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  runed@0.20.0(svelte@5.16.1):
-    dependencies:
-      esm-env: 1.2.1
-      svelte: 5.16.1
-
   runed@0.23.2(svelte@5.16.1):
     dependencies:
       esm-env: 1.2.1
@@ -5336,10 +5348,16 @@ snapshots:
       style-to-object: 1.0.8
       svelte: 5.16.1
 
-  svelte-toolbelt@0.7.0(svelte@5.16.1):
+  svelte-toolbelt@0.5.0(svelte@5.16.1):
     dependencies:
       clsx: 2.1.1
-      runed: 0.20.0(svelte@5.16.1)
+      style-to-object: 1.0.8
+      svelte: 5.16.1
+
+  svelte-toolbelt@0.7.1(svelte@5.16.1):
+    dependencies:
+      clsx: 2.1.1
+      runed: 0.23.2(svelte@5.16.1)
       style-to-object: 1.0.8
       svelte: 5.16.1
 
@@ -5525,7 +5543,7 @@ snapshots:
 
   vaul-svelte@1.0.0-next.3(svelte@5.16.1):
     dependencies:
-      bits-ui: 1.0.0-next.81(svelte@5.16.1)
+      bits-ui: 1.0.0-next.85(svelte@5.16.1)
       svelte: 5.16.1
       svelte-toolbelt: 0.4.6(svelte@5.16.1)
 

--- a/src/app.css
+++ b/src/app.css
@@ -35,6 +35,7 @@
 		--input: 20 5.9% 90%;
 		--ring: 20 14.3% 4.1%;
 		--radius: 0.5rem;
+		--danger: 0, 84%, 60%;
 
 		--sidebar-background: 0 0% 98%;
 		--sidebar-foreground: 240 5.3% 26.1%;
@@ -65,6 +66,7 @@
 		--border: 12 6.5% 15.1%;
 		--input: 12 6.5% 15.1%;
 		--ring: 35.5 91.7% 32.9%;
+		--danger: 0, 84%, 60%;
 
 		--sidebar-background: 240 5.9% 10%;
 		--sidebar-foreground: 240 4.8% 95.9%;

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -15,6 +15,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 		return resolve(event);
 	}
 
+	// Routes with /p which stands for public, do not require authentication
 	if (event.url.pathname.startsWith('/p')) {
 		return resolve(event);
 	}

--- a/src/lib/components/custom/account/user-webhook-card.svelte
+++ b/src/lib/components/custom/account/user-webhook-card.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import { invalidate } from '$app/navigation';
+	import * as AlertDialog from '$lib/components/ui/alert-dialog/index.js';
+	import { Button } from '$lib/components/ui/button';
+	import { toast } from 'svelte-sonner';
+	type Props = {
+		hook: {
+			id: string;
+			name: string;
+			userId: string;
+			type: 'discord';
+			webhook: string;
+			events: string[];
+			createdAt: Date;
+			lastUsed: Date;
+			successCount: number | null;
+			failureCount: number | null;
+		};
+		action: string;
+		depends?: string;
+	};
+
+	let { hook, action, depends }: Props = $props();
+	let dialogOpen = $state(false);
+</script>
+
+<div class="flex flex-col gap-2">
+	<div class="flex flex-row items-center justify-between rounded-md border p-2">
+		<div class="flex flex-col">
+			<div class="mb-3 flex flex-col">
+				<h4 class="text-primary">{hook.name}</h4>
+				<p class="text-xs text-muted-foreground">{hook.webhook}</p>
+			</div>
+			<p class="text-sm">Events: {hook.events.join(', ')}</p>
+		</div>
+
+		<AlertDialog.Root bind:open={dialogOpen}>
+			<AlertDialog.Trigger>
+				<Button size="sm" variant="action" class="text-danger">Delete</Button>
+			</AlertDialog.Trigger>
+			<AlertDialog.Content>
+				<AlertDialog.Header>
+					<AlertDialog.Title>Are you absolutely sure?</AlertDialog.Title>
+					<AlertDialog.Description>
+						This action cannot be undone. This will permanently delete your account and remove your
+						data from our servers.
+					</AlertDialog.Description>
+				</AlertDialog.Header>
+				<AlertDialog.Footer>
+					<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+					<form
+						{action}
+						method="POST"
+						use:enhance={() => {
+							return async ({ result, update }) => {
+								switch (result.type) {
+									case 'success':
+										dialogOpen = false;
+										toast('Hook has been deleted');
+										if (depends) {
+											await invalidate(depends);
+										}
+										break;
+									case 'error':
+										toast.error('An error occurred when trying to delete the webhook.');
+										console.log(result.error);
+										break;
+									case 'failure':
+										toast.error('Failed to delete hook');
+										break;
+								}
+							};
+						}}
+					>
+						<AlertDialog.Action name="id" value={hook.id}>Yes, Delete</AlertDialog.Action>
+					</form>
+				</AlertDialog.Footer>
+			</AlertDialog.Content>
+		</AlertDialog.Root>
+	</div>
+</div>

--- a/src/lib/components/ui/form/form-button.svelte
+++ b/src/lib/components/ui/form/form-button.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import * as Button from "$lib/components/ui/button/index.js";
+
+	let { ref = $bindable(null), ...restProps }: Button.Props = $props();
+</script>
+
+<Button.Root bind:ref type="submit" {...restProps} />

--- a/src/lib/components/ui/form/form-button.svelte
+++ b/src/lib/components/ui/form/form-button.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import * as Button from "$lib/components/ui/button/index.js";
+	import * as Button from '$lib/components/ui/button/index.js';
 
 	let { ref = $bindable(null), ...restProps }: Button.Props = $props();
 </script>

--- a/src/lib/components/ui/form/form-description.svelte
+++ b/src/lib/components/ui/form/form-description.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import * as FormPrimitive from "formsnap";
+	import type { WithoutChild } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: WithoutChild<FormPrimitive.DescriptionProps> = $props();
+</script>
+
+<FormPrimitive.Description
+	bind:ref
+	class={cn("text-muted-foreground text-sm", className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/form/form-description.svelte
+++ b/src/lib/components/ui/form/form-description.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import * as FormPrimitive from "formsnap";
-	import type { WithoutChild } from "bits-ui";
-	import { cn } from "$lib/utils.js";
+	import * as FormPrimitive from 'formsnap';
+	import type { WithoutChild } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
 
 	let {
 		ref = $bindable(null),
@@ -12,6 +12,6 @@
 
 <FormPrimitive.Description
 	bind:ref
-	class={cn("text-muted-foreground text-sm", className)}
+	class={cn('text-sm text-muted-foreground', className)}
 	{...restProps}
 />

--- a/src/lib/components/ui/form/form-element-field.svelte
+++ b/src/lib/components/ui/form/form-element-field.svelte
@@ -1,0 +1,30 @@
+<script lang="ts" module>
+	import type { FormPathLeaves as _FormPathLeaves } from "sveltekit-superforms";
+	type T = Record<string, unknown>;
+	type U = _FormPathLeaves<T>;
+</script>
+
+<script lang="ts" generics="T extends Record<string, unknown>, U extends _FormPathLeaves<T>">
+	import * as FormPrimitive from "formsnap";
+	import type { HTMLAttributes } from "svelte/elements";
+	import type { WithElementRef, WithoutChildren } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		form,
+		name,
+		children: childrenProp,
+		...restProps
+	}: WithoutChildren<WithElementRef<HTMLAttributes<HTMLDivElement>>> &
+		FormPrimitive.ElementFieldProps<T, U> = $props();
+</script>
+
+<FormPrimitive.ElementField {form} {name}>
+	{#snippet children({ constraints, errors, tainted, value })}
+		<div bind:this={ref} class={cn("space-y-2", className)} {...restProps}>
+			{@render childrenProp?.({ constraints, errors, tainted, value: value as T[U] })}
+		</div>
+	{/snippet}
+</FormPrimitive.ElementField>

--- a/src/lib/components/ui/form/form-element-field.svelte
+++ b/src/lib/components/ui/form/form-element-field.svelte
@@ -1,14 +1,14 @@
 <script lang="ts" module>
-	import type { FormPathLeaves as _FormPathLeaves } from "sveltekit-superforms";
+	import type { FormPathLeaves as _FormPathLeaves } from 'sveltekit-superforms';
 	type T = Record<string, unknown>;
 	type U = _FormPathLeaves<T>;
 </script>
 
 <script lang="ts" generics="T extends Record<string, unknown>, U extends _FormPathLeaves<T>">
-	import * as FormPrimitive from "formsnap";
-	import type { HTMLAttributes } from "svelte/elements";
-	import type { WithElementRef, WithoutChildren } from "bits-ui";
-	import { cn } from "$lib/utils.js";
+	import * as FormPrimitive from 'formsnap';
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { WithElementRef, WithoutChildren } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
 
 	let {
 		ref = $bindable(null),
@@ -23,7 +23,7 @@
 
 <FormPrimitive.ElementField {form} {name}>
 	{#snippet children({ constraints, errors, tainted, value })}
-		<div bind:this={ref} class={cn("space-y-2", className)} {...restProps}>
+		<div bind:this={ref} class={cn('space-y-2', className)} {...restProps}>
 			{@render childrenProp?.({ constraints, errors, tainted, value: value as T[U] })}
 		</div>
 	{/snippet}

--- a/src/lib/components/ui/form/form-field-errors.svelte
+++ b/src/lib/components/ui/form/form-field-errors.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import * as FormPrimitive from "formsnap";
+	import type { WithoutChild } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		errorClasses,
+		children: childrenProp,
+		...restProps
+	}: WithoutChild<FormPrimitive.FieldErrorsProps> & {
+		errorClasses?: string | undefined | null;
+	} = $props();
+</script>
+
+<FormPrimitive.FieldErrors
+	bind:ref
+	class={cn("text-destructive text-sm font-medium", className)}
+	{...restProps}
+>
+	{#snippet children({ errors, errorProps })}
+		{#if childrenProp}
+			{@render childrenProp({ errors, errorProps })}
+		{:else}
+			{#each errors as error}
+				<div {...errorProps} class={cn(errorClasses)}>{error}</div>
+			{/each}
+		{/if}
+	{/snippet}
+</FormPrimitive.FieldErrors>

--- a/src/lib/components/ui/form/form-field-errors.svelte
+++ b/src/lib/components/ui/form/form-field-errors.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import * as FormPrimitive from "formsnap";
-	import type { WithoutChild } from "bits-ui";
-	import { cn } from "$lib/utils.js";
+	import * as FormPrimitive from 'formsnap';
+	import type { WithoutChild } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
 
 	let {
 		ref = $bindable(null),
@@ -16,7 +16,7 @@
 
 <FormPrimitive.FieldErrors
 	bind:ref
-	class={cn("text-destructive text-sm font-medium", className)}
+	class={cn('text-sm font-medium text-destructive', className)}
 	{...restProps}
 >
 	{#snippet children({ errors, errorProps })}

--- a/src/lib/components/ui/form/form-field.svelte
+++ b/src/lib/components/ui/form/form-field.svelte
@@ -1,0 +1,30 @@
+<script lang="ts" module>
+	import type { FormPath as _FormPath } from "sveltekit-superforms";
+	type T = Record<string, unknown>;
+	type U = _FormPath<T>;
+</script>
+
+<script lang="ts" generics="T extends Record<string, unknown>, U extends _FormPath<T>">
+	import * as FormPrimitive from "formsnap";
+	import type { WithoutChildren, WithElementRef } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		form,
+		name,
+		children: childrenProp,
+		...restProps
+	}: FormPrimitive.FieldProps<T, U> &
+		WithoutChildren<WithElementRef<HTMLAttributes<HTMLDivElement>>> = $props();
+</script>
+
+<FormPrimitive.Field {form} {name}>
+	{#snippet children({ constraints, errors, tainted, value })}
+		<div bind:this={ref} class={cn("space-y-2", className)} {...restProps}>
+			{@render childrenProp?.({ constraints, errors, tainted, value: value as T[U] })}
+		</div>
+	{/snippet}
+</FormPrimitive.Field>

--- a/src/lib/components/ui/form/form-field.svelte
+++ b/src/lib/components/ui/form/form-field.svelte
@@ -1,14 +1,14 @@
 <script lang="ts" module>
-	import type { FormPath as _FormPath } from "sveltekit-superforms";
+	import type { FormPath as _FormPath } from 'sveltekit-superforms';
 	type T = Record<string, unknown>;
 	type U = _FormPath<T>;
 </script>
 
 <script lang="ts" generics="T extends Record<string, unknown>, U extends _FormPath<T>">
-	import * as FormPrimitive from "formsnap";
-	import type { WithoutChildren, WithElementRef } from "bits-ui";
-	import { cn } from "$lib/utils.js";
-	import type { HTMLAttributes } from "svelte/elements";
+	import * as FormPrimitive from 'formsnap';
+	import type { WithoutChildren, WithElementRef } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
+	import type { HTMLAttributes } from 'svelte/elements';
 
 	let {
 		ref = $bindable(null),
@@ -23,7 +23,7 @@
 
 <FormPrimitive.Field {form} {name}>
 	{#snippet children({ constraints, errors, tainted, value })}
-		<div bind:this={ref} class={cn("space-y-2", className)} {...restProps}>
+		<div bind:this={ref} class={cn('space-y-2', className)} {...restProps}>
 			{@render childrenProp?.({ constraints, errors, tainted, value: value as T[U] })}
 		</div>
 	{/snippet}

--- a/src/lib/components/ui/form/form-fieldset.svelte
+++ b/src/lib/components/ui/form/form-fieldset.svelte
@@ -1,0 +1,21 @@
+<script lang="ts" module>
+	import type { FormPath as _FormPath } from "sveltekit-superforms";
+	type T = Record<string, unknown>;
+	type U = _FormPath<T>;
+</script>
+
+<script lang="ts" generics="T extends Record<string, unknown>, U extends _FormPath<T>">
+	import * as FormPrimitive from "formsnap";
+	import type { WithoutChild } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		form,
+		name,
+		...restProps
+	}: WithoutChild<FormPrimitive.FieldsetProps<T, U>> = $props();
+</script>
+
+<FormPrimitive.Fieldset bind:ref {form} {name} class={cn("space-y-2", className)} {...restProps} />

--- a/src/lib/components/ui/form/form-fieldset.svelte
+++ b/src/lib/components/ui/form/form-fieldset.svelte
@@ -1,13 +1,13 @@
 <script lang="ts" module>
-	import type { FormPath as _FormPath } from "sveltekit-superforms";
+	import type { FormPath as _FormPath } from 'sveltekit-superforms';
 	type T = Record<string, unknown>;
 	type U = _FormPath<T>;
 </script>
 
 <script lang="ts" generics="T extends Record<string, unknown>, U extends _FormPath<T>">
-	import * as FormPrimitive from "formsnap";
-	import type { WithoutChild } from "bits-ui";
-	import { cn } from "$lib/utils.js";
+	import * as FormPrimitive from 'formsnap';
+	import type { WithoutChild } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
 
 	let {
 		ref = $bindable(null),
@@ -18,4 +18,4 @@
 	}: WithoutChild<FormPrimitive.FieldsetProps<T, U>> = $props();
 </script>
 
-<FormPrimitive.Fieldset bind:ref {form} {name} class={cn("space-y-2", className)} {...restProps} />
+<FormPrimitive.Fieldset bind:ref {form} {name} class={cn('space-y-2', className)} {...restProps} />

--- a/src/lib/components/ui/form/form-label.svelte
+++ b/src/lib/components/ui/form/form-label.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import type { WithoutChild } from "bits-ui";
+	import * as FormPrimitive from "formsnap";
+	import { Label } from "$lib/components/ui/label/index.js";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		children,
+		class: className,
+		...restProps
+	}: WithoutChild<FormPrimitive.LabelProps> = $props();
+</script>
+
+<FormPrimitive.Label {...restProps} bind:ref>
+	{#snippet child({ props })}
+		<Label {...props} class={cn("data-[fs-error]:text-destructive", className)}>
+			{@render children?.()}
+		</Label>
+	{/snippet}
+</FormPrimitive.Label>

--- a/src/lib/components/ui/form/form-label.svelte
+++ b/src/lib/components/ui/form/form-label.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-	import type { WithoutChild } from "bits-ui";
-	import * as FormPrimitive from "formsnap";
-	import { Label } from "$lib/components/ui/label/index.js";
-	import { cn } from "$lib/utils.js";
+	import type { WithoutChild } from 'bits-ui';
+	import * as FormPrimitive from 'formsnap';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import { cn } from '$lib/utils.js';
 
 	let {
 		ref = $bindable(null),
@@ -14,7 +14,7 @@
 
 <FormPrimitive.Label {...restProps} bind:ref>
 	{#snippet child({ props })}
-		<Label {...props} class={cn("data-[fs-error]:text-destructive", className)}>
+		<Label {...props} class={cn('data-[fs-error]:text-destructive', className)}>
 			{@render children?.()}
 		</Label>
 	{/snippet}

--- a/src/lib/components/ui/form/form-legend.svelte
+++ b/src/lib/components/ui/form/form-legend.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import * as FormPrimitive from "formsnap";
+	import type { WithoutChild } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: WithoutChild<FormPrimitive.LegendProps> = $props();
+</script>
+
+<FormPrimitive.Legend
+	bind:ref
+	class={cn("data-[fs-error]:text-destructive text-sm font-medium leading-none", className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/form/form-legend.svelte
+++ b/src/lib/components/ui/form/form-legend.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import * as FormPrimitive from "formsnap";
-	import type { WithoutChild } from "bits-ui";
-	import { cn } from "$lib/utils.js";
+	import * as FormPrimitive from 'formsnap';
+	import type { WithoutChild } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
 
 	let {
 		ref = $bindable(null),
@@ -12,6 +12,6 @@
 
 <FormPrimitive.Legend
 	bind:ref
-	class={cn("data-[fs-error]:text-destructive text-sm font-medium leading-none", className)}
+	class={cn('text-sm font-medium leading-none data-[fs-error]:text-destructive', className)}
 	{...restProps}
 />

--- a/src/lib/components/ui/form/index.ts
+++ b/src/lib/components/ui/form/index.ts
@@ -1,12 +1,12 @@
-import * as FormPrimitive from "formsnap";
-import Description from "./form-description.svelte";
-import Label from "./form-label.svelte";
-import FieldErrors from "./form-field-errors.svelte";
-import Field from "./form-field.svelte";
-import Fieldset from "./form-fieldset.svelte";
-import Legend from "./form-legend.svelte";
-import ElementField from "./form-element-field.svelte";
-import Button from "./form-button.svelte";
+import * as FormPrimitive from 'formsnap';
+import Description from './form-description.svelte';
+import Label from './form-label.svelte';
+import FieldErrors from './form-field-errors.svelte';
+import Field from './form-field.svelte';
+import Fieldset from './form-fieldset.svelte';
+import Legend from './form-legend.svelte';
+import ElementField from './form-element-field.svelte';
+import Button from './form-button.svelte';
 
 const Control = FormPrimitive.Control;
 
@@ -29,5 +29,5 @@ export {
 	Fieldset as FormFieldset,
 	Legend as FormLegend,
 	ElementField as FormElementField,
-	Button as FormButton,
+	Button as FormButton
 };

--- a/src/lib/components/ui/form/index.ts
+++ b/src/lib/components/ui/form/index.ts
@@ -1,0 +1,33 @@
+import * as FormPrimitive from "formsnap";
+import Description from "./form-description.svelte";
+import Label from "./form-label.svelte";
+import FieldErrors from "./form-field-errors.svelte";
+import Field from "./form-field.svelte";
+import Fieldset from "./form-fieldset.svelte";
+import Legend from "./form-legend.svelte";
+import ElementField from "./form-element-field.svelte";
+import Button from "./form-button.svelte";
+
+const Control = FormPrimitive.Control;
+
+export {
+	Field,
+	Control,
+	Label,
+	Button,
+	FieldErrors,
+	Description,
+	Fieldset,
+	Legend,
+	ElementField,
+	//
+	Field as FormField,
+	Control as FormControl,
+	Description as FormDescription,
+	Label as FormLabel,
+	FieldErrors as FormFieldErrors,
+	Fieldset as FormFieldset,
+	Legend as FormLegend,
+	ElementField as FormElementField,
+	Button as FormButton,
+};

--- a/src/lib/components/ui/menubar/index.ts
+++ b/src/lib/components/ui/menubar/index.ts
@@ -1,15 +1,15 @@
-import { Menubar as MenubarPrimitive } from "bits-ui";
-import Root from "./menubar.svelte";
-import CheckboxItem from "./menubar-checkbox-item.svelte";
-import Content from "./menubar-content.svelte";
-import Item from "./menubar-item.svelte";
-import GroupHeading from "./menubar-group-heading.svelte";
-import RadioItem from "./menubar-radio-item.svelte";
-import Separator from "./menubar-separator.svelte";
-import Shortcut from "./menubar-shortcut.svelte";
-import SubContent from "./menubar-sub-content.svelte";
-import SubTrigger from "./menubar-sub-trigger.svelte";
-import Trigger from "./menubar-trigger.svelte";
+import { Menubar as MenubarPrimitive } from 'bits-ui';
+import Root from './menubar.svelte';
+import CheckboxItem from './menubar-checkbox-item.svelte';
+import Content from './menubar-content.svelte';
+import Item from './menubar-item.svelte';
+import GroupHeading from './menubar-group-heading.svelte';
+import RadioItem from './menubar-radio-item.svelte';
+import Separator from './menubar-separator.svelte';
+import Shortcut from './menubar-shortcut.svelte';
+import SubContent from './menubar-sub-content.svelte';
+import SubTrigger from './menubar-sub-trigger.svelte';
+import Trigger from './menubar-trigger.svelte';
 
 const Menu = MenubarPrimitive.Menu;
 const Group = MenubarPrimitive.Group;
@@ -47,5 +47,5 @@ export {
 	Menu as MenubarMenu,
 	Group as MenubarGroup,
 	Sub as MenubarSub,
-	RadioGroup as MenubarRadioGroup,
+	RadioGroup as MenubarRadioGroup
 };

--- a/src/lib/components/ui/menubar/menubar-checkbox-item.svelte
+++ b/src/lib/components/ui/menubar/menubar-checkbox-item.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-	import { Menubar as MenubarPrimitive, type WithoutChildrenOrChild } from "bits-ui";
-	import Check from "lucide-svelte/icons/check";
-	import Minus from "lucide-svelte/icons/minus";
-	import { cn } from "$lib/utils.js";
-	import type { Snippet } from "svelte";
+	import { Menubar as MenubarPrimitive, type WithoutChildrenOrChild } from 'bits-ui';
+	import Check from 'lucide-svelte/icons/check';
+	import Minus from 'lucide-svelte/icons/minus';
+	import { cn } from '$lib/utils.js';
+	import type { Snippet } from 'svelte';
 
 	let {
 		ref = $bindable(null),
@@ -22,7 +22,7 @@
 	bind:checked
 	bind:indeterminate
 	class={cn(
-		"data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+		'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none data-[disabled]:pointer-events-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:opacity-50',
 		className
 	)}
 	{...restProps}
@@ -32,7 +32,7 @@
 			{#if indeterminate}
 				<Minus class="size-4" />
 			{:else}
-				<Check class={cn("size-4", !checked && "text-transparent")} />
+				<Check class={cn('size-4', !checked && 'text-transparent')} />
 			{/if}
 		</span>
 		{@render childrenProp?.()}

--- a/src/lib/components/ui/menubar/menubar-content.svelte
+++ b/src/lib/components/ui/menubar/menubar-content.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
-	import { Menubar as MenubarPrimitive } from "bits-ui";
-	import { cn } from "$lib/utils.js";
+	import { Menubar as MenubarPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
 
 	let {
 		ref = $bindable(null),
 		class: className,
 		sideOffset = 8,
 		alignOffset = -4,
-		align = "start",
-		side = "bottom",
+		align = 'start',
+		side = 'bottom',
 		portalProps,
 		...restProps
 	}: MenubarPrimitive.ContentProps & {
@@ -24,7 +24,7 @@
 		{alignOffset}
 		{side}
 		class={cn(
-			"bg-popover text-popover-foreground z-50 min-w-[12rem] rounded-md border p-1 shadow-md focus:outline-none",
+			'z-50 min-w-[12rem] rounded-md border bg-popover p-1 text-popover-foreground shadow-md focus:outline-none',
 			className
 		)}
 		{...restProps}

--- a/src/lib/components/ui/menubar/menubar-group-heading.svelte
+++ b/src/lib/components/ui/menubar/menubar-group-heading.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { Menubar as MenubarPrimitive } from "bits-ui";
-	import { cn } from "$lib/utils.js";
+	import { Menubar as MenubarPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
 
 	let {
 		ref = $bindable(null),
@@ -14,6 +14,6 @@
 
 <MenubarPrimitive.GroupHeading
 	bind:ref
-	class={cn("px-2 py-1.5 text-sm font-semibold", inset && "pl-8", className)}
+	class={cn('px-2 py-1.5 text-sm font-semibold', inset && 'pl-8', className)}
 	{...restProps}
 />

--- a/src/lib/components/ui/menubar/menubar-item.svelte
+++ b/src/lib/components/ui/menubar/menubar-item.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { Menubar as MenubarPrimitive } from "bits-ui";
-	import { cn } from "$lib/utils.js";
+	import { Menubar as MenubarPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
 
 	let {
 		ref = $bindable(null),
@@ -15,8 +15,8 @@
 <MenubarPrimitive.Item
 	bind:ref
 	class={cn(
-		"data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-		inset && "pl-8",
+		'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled]:pointer-events-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:opacity-50',
+		inset && 'pl-8',
 		className
 	)}
 	{...restProps}

--- a/src/lib/components/ui/menubar/menubar-radio-item.svelte
+++ b/src/lib/components/ui/menubar/menubar-radio-item.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { Menubar as MenubarPrimitive, type WithoutChild } from "bits-ui";
-	import Circle from "lucide-svelte/icons/circle";
-	import { cn } from "$lib/utils.js";
+	import { Menubar as MenubarPrimitive, type WithoutChild } from 'bits-ui';
+	import Circle from 'lucide-svelte/icons/circle';
+	import { cn } from '$lib/utils.js';
 
 	let {
 		ref = $bindable(null),
@@ -14,7 +14,7 @@
 <MenubarPrimitive.RadioItem
 	bind:ref
 	class={cn(
-		"data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+		'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none data-[disabled]:pointer-events-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:opacity-50',
 		className
 	)}
 	{...restProps}

--- a/src/lib/components/ui/menubar/menubar-separator.svelte
+++ b/src/lib/components/ui/menubar/menubar-separator.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { Menubar as MenubarPrimitive } from "bits-ui";
-	import { cn } from "$lib/utils.js";
+	import { Menubar as MenubarPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
 
 	let {
 		ref = $bindable(null),
@@ -11,6 +11,6 @@
 
 <MenubarPrimitive.Separator
 	bind:ref
-	class={cn("bg-muted -mx-1 my-1 h-px", className)}
+	class={cn('-mx-1 my-1 h-px bg-muted', className)}
 	{...restProps}
 />

--- a/src/lib/components/ui/menubar/menubar-shortcut.svelte
+++ b/src/lib/components/ui/menubar/menubar-shortcut.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import type { HTMLAttributes } from "svelte/elements";
-	import type { WithElementRef } from "bits-ui";
-	import { cn } from "$lib/utils.js";
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { WithElementRef } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
 
 	let {
 		ref = $bindable(null),
@@ -13,7 +13,7 @@
 
 <span
 	bind:this={ref}
-	class={cn("text-muted-foreground ml-auto text-xs tracking-widest", className)}
+	class={cn('ml-auto text-xs tracking-widest text-muted-foreground', className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/src/lib/components/ui/menubar/menubar-sub-content.svelte
+++ b/src/lib/components/ui/menubar/menubar-sub-content.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { Menubar as MenubarPrimitive } from "bits-ui";
-	import { cn } from "$lib/utils.js";
+	import { Menubar as MenubarPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
 
 	let {
 		ref = $bindable(null),
@@ -12,7 +12,7 @@
 <MenubarPrimitive.SubContent
 	bind:ref
 	class={cn(
-		"bg-popover text-popover-foreground z-50 min-w-max rounded-md border p-1 focus:outline-none",
+		'z-50 min-w-max rounded-md border bg-popover p-1 text-popover-foreground focus:outline-none',
 		className
 	)}
 	{...restProps}

--- a/src/lib/components/ui/menubar/menubar-sub-trigger.svelte
+++ b/src/lib/components/ui/menubar/menubar-sub-trigger.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { Menubar as MenubarPrimitive, type WithoutChild } from "bits-ui";
-	import ChevronRight from "lucide-svelte/icons/chevron-right";
-	import { cn } from "$lib/utils.js";
+	import { Menubar as MenubarPrimitive, type WithoutChild } from 'bits-ui';
+	import ChevronRight from 'lucide-svelte/icons/chevron-right';
+	import { cn } from '$lib/utils.js';
 
 	let {
 		ref = $bindable(null),
@@ -17,8 +17,8 @@
 <MenubarPrimitive.SubTrigger
 	bind:ref
 	class={cn(
-		"data-[highlighted]:bg-accent data-[state=open]:bg-accent data-[highlighted]:text-accent-foreground data-[state=open]:text-accent-foreground flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-		inset && "pl-8",
+		'flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled]:pointer-events-none data-[highlighted]:bg-accent data-[state=open]:bg-accent data-[highlighted]:text-accent-foreground data-[state=open]:text-accent-foreground data-[disabled]:opacity-50',
+		inset && 'pl-8',
 		className
 	)}
 	{...restProps}

--- a/src/lib/components/ui/menubar/menubar-trigger.svelte
+++ b/src/lib/components/ui/menubar/menubar-trigger.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { Menubar as MenubarPrimitive } from "bits-ui";
-	import { cn } from "$lib/utils.js";
+	import { Menubar as MenubarPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
 
 	let {
 		ref = $bindable(null),
@@ -12,7 +12,7 @@
 <MenubarPrimitive.Trigger
 	bind:ref
 	class={cn(
-		"data-[highlighted]:bg-accent data-[state=open]:bg-accent data-[highlighted]:text-accent-foreground data-[state=open]:text-accent-foreground flex cursor-default select-none items-center rounded-sm px-3 py-1.5 text-sm font-medium outline-none",
+		'flex cursor-default select-none items-center rounded-sm px-3 py-1.5 text-sm font-medium outline-none data-[highlighted]:bg-accent data-[state=open]:bg-accent data-[highlighted]:text-accent-foreground data-[state=open]:text-accent-foreground',
 		className
 	)}
 	{...restProps}

--- a/src/lib/components/ui/menubar/menubar.svelte
+++ b/src/lib/components/ui/menubar/menubar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { Menubar as MenubarPrimitive } from "bits-ui";
-	import { cn } from "$lib/utils.js";
+	import { Menubar as MenubarPrimitive } from 'bits-ui';
+	import { cn } from '$lib/utils.js';
 
 	let {
 		ref = $bindable(null),
@@ -11,6 +11,6 @@
 
 <MenubarPrimitive.Root
 	bind:ref
-	class={cn("bg-background flex h-10 items-center space-x-1 rounded-md border p-1", className)}
+	class={cn('flex h-10 items-center space-x-1 rounded-md border bg-background p-1', className)}
 	{...restProps}
 />

--- a/src/lib/consts/webhook-event.ts
+++ b/src/lib/consts/webhook-event.ts
@@ -1,1 +1,1 @@
-export const WebhookEvent = ['auction_started', 'auction_listing_created'] as const;
+export const WebhookEvent = ['auction_listing_created'] as const;

--- a/src/lib/consts/webhook-event.ts
+++ b/src/lib/consts/webhook-event.ts
@@ -1,0 +1,1 @@
+export const WebhookEvent = ['auction_started', 'auction_listing_created'] as const;

--- a/src/lib/hooks/server/auctions/new-listing.hook.ts
+++ b/src/lib/hooks/server/auctions/new-listing.hook.ts
@@ -1,0 +1,86 @@
+import { env } from '$env/dynamic/private';
+import { WebhookEvent } from '$lib/consts/webhook-event';
+import { db } from '$lib/server/db';
+import axios from 'axios';
+import { sql } from 'drizzle-orm';
+
+/**
+ * This function is called when a new auction listing is created. This will
+ * send a webhook to all users who have subscribed to the event.
+ *
+ * Handles the `auction_listing_created` event.
+ * @param id {string} Auction Listing ID
+ * @returns
+ */
+export async function onNewAuctionListingHook(id: string) {
+	const record = await db.query.auctionListings.findFirst({
+		where: (r, { eq }) => eq(r.id, id),
+		with: {
+			items: {
+				with: {
+					asset: true,
+					entity: true
+				}
+			}
+		}
+	});
+
+	if (!record) {
+		console.log('Auction listing was not found in the holochain.');
+		return;
+	}
+
+	if (record.status != 'new') {
+		console.log('Auction listing is not new.');
+		return;
+	}
+
+	const availableWebhooks = await db.query.userWebhooks.findMany({
+		where: (r) => sql`${r.events} @> ARRAY['auction_listing_created']::text[]`
+	});
+
+	const embed = {
+		embeds: [
+			{
+				title: `New Auction Listing - ALID: ${record.listingNumber}`,
+				description: `
+              **Listing Title**:
+              ${record?.title}
+
+               **Starting Bid**: 
+              ${record?.startingPrice}
+  
+              **Location**:
+              ${record?.location}
+            `,
+				url: `${env.UIM_BASE_URL}/auctions/listings/${record?.id}`,
+				author: {
+					name: 'Unnamed Market',
+					icon_url: `${env.UIM_BASE_URL}/assets/uim-18.png`
+				},
+				fields: record?.items.map((item) => {
+					return {
+						name: 'Item',
+						value: item.customItemName ? item.customItemName : item.entity?.name,
+						inline: true
+					};
+				}),
+				thumbnail: {
+					url: `${env.UIM_BASE_URL}/assets/uim-18.png`
+				},
+				image: {
+					url: `${env.UIM_BASE_URL}/assets/unnamed-banner.png`
+				},
+				footer: {
+					text: 'Unnamed Market - Your gateway to the holochain',
+					icon_url: `${env.UIM_BASE_URL}/assets/uim-18.png`
+				},
+				timestamp: new Date()
+			}
+		]
+	};
+
+	for (const hook of availableWebhooks) {
+		await axios.post(hook.webhook, embed);
+	}
+}

--- a/src/lib/models/zod/users/user-hooks.schema.ts
+++ b/src/lib/models/zod/users/user-hooks.schema.ts
@@ -1,0 +1,13 @@
+import { WebhookEvent } from '$lib/consts/webhook-event';
+import { z } from 'zod';
+
+export const userHooksSchema = z.object({
+	name: z.string(),
+	type: z.enum(['discord']),
+	webhook: z.string().url({ message: 'Must be a valid URL' }),
+	events: z.array(
+		z.enum(WebhookEvent).refine((v) => {
+			return WebhookEvent.includes(v);
+		})
+	)
+});

--- a/src/lib/server/db/migrations/20250204162432_silent_juggernaut.sql
+++ b/src/lib/server/db/migrations/20250204162432_silent_juggernaut.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "user_webhooks" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"name" text NOT NULL,
+	"type" text DEFAULT 'discord' NOT NULL,
+	"webhook" text NOT NULL,
+	"events" text[] NOT NULL,
+	CONSTRAINT "user_webhooks_id_unique" UNIQUE("id")
+);
+--> statement-breakpoint
+ALTER TABLE "user_webhooks" ADD CONSTRAINT "user_webhooks_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;

--- a/src/lib/server/db/migrations/20250204170946_parallel_thunderbird.sql
+++ b/src/lib/server/db/migrations/20250204170946_parallel_thunderbird.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "user_webhooks" ADD COLUMN "created_at" timestamp NOT NULL;--> statement-breakpoint
+ALTER TABLE "user_webhooks" ADD COLUMN "last_used" timestamp NOT NULL;--> statement-breakpoint
+ALTER TABLE "user_webhooks" ADD COLUMN "success_count" integer DEFAULT 0;--> statement-breakpoint
+ALTER TABLE "user_webhooks" ADD COLUMN "failure_count" integer DEFAULT 0;

--- a/src/lib/server/db/migrations/meta/20250204162432_snapshot.json
+++ b/src/lib/server/db/migrations/meta/20250204162432_snapshot.json
@@ -1,0 +1,821 @@
+{
+  "id": "bdef37f0-8eea-4502-81b5-ac687ec16ebe",
+  "prevId": "01acad43-09e5-4bd2-a718-83399d285711",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "combine_id": {
+          "name": "combine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "join_date": {
+          "name": "join_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'patron'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned_reason": {
+          "name": "banned_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires": {
+          "name": "refresh_token_expires",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_id_unique": {
+          "name": "users_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        },
+        "users_name_unique": {
+          "name": "users_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "users_combine_id_unique": {
+          "name": "users_combine_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "combine_id"
+          ]
+        },
+        "users_discord_id_unique": {
+          "name": "users_discord_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uid": {
+          "name": "uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_link": {
+          "name": "api_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "entities_id_unique": {
+          "name": "entities_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        },
+        "entities_uid_unique": {
+          "name": "entities_uid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "combine_id": {
+          "name": "combine_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_image_url": {
+          "name": "custom_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "assets_id_unique": {
+          "name": "assets_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset_ledger": {
+      "name": "asset_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time": {
+          "name": "time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "asset_ledger_asset_id_assets_id_fk": {
+          "name": "asset_ledger_asset_id_assets_id_fk",
+          "tableFrom": "asset_ledger",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "asset_ledger_id_unique": {
+          "name": "asset_ledger_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auction_listings": {
+      "name": "auction_listings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "listing_number": {
+          "name": "listing_number",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "listed_by_id": {
+          "name": "listed_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starting_price": {
+          "name": "starting_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchased_by_id": {
+          "name": "purchased_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchased_price": {
+          "name": "purchased_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_credits_to_id": {
+          "name": "sent_credits_to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lister_is_anon": {
+          "name": "lister_is_anon",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "auction_id": {
+          "name": "auction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auction_listings_listed_by_id_users_id_fk": {
+          "name": "auction_listings_listed_by_id_users_id_fk",
+          "tableFrom": "auction_listings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "listed_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "auction_listings_purchased_by_id_users_id_fk": {
+          "name": "auction_listings_purchased_by_id_users_id_fk",
+          "tableFrom": "auction_listings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "purchased_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "auction_listings_auction_id_auctions_id_fk": {
+          "name": "auction_listings_auction_id_auctions_id_fk",
+          "tableFrom": "auction_listings",
+          "tableTo": "auctions",
+          "columnsFrom": [
+            "auction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auction_listings_id_unique": {
+          "name": "auction_listings_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auction_listing_items": {
+      "name": "auction_listing_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "listing_id": {
+          "name": "listing_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uuu": {
+          "name": "uuu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "custom_item": {
+          "name": "custom_item",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "custom_image_url": {
+          "name": "custom_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_item_name": {
+          "name": "custom_item_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unique_item": {
+          "name": "unique_item",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auction_listing_items_listing_id_auction_listings_id_fk": {
+          "name": "auction_listing_items_listing_id_auction_listings_id_fk",
+          "tableFrom": "auction_listing_items",
+          "tableTo": "auction_listings",
+          "columnsFrom": [
+            "listing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "auction_listing_items_asset_id_assets_id_fk": {
+          "name": "auction_listing_items_asset_id_assets_id_fk",
+          "tableFrom": "auction_listing_items",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auction_listing_items_id_unique": {
+          "name": "auction_listing_items_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auction_listing_history": {
+      "name": "auction_listing_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "listing_id": {
+          "name": "listing_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auction_listing_history_listing_id_auction_listings_id_fk": {
+          "name": "auction_listing_history_listing_id_auction_listings_id_fk",
+          "tableFrom": "auction_listing_history",
+          "tableTo": "auction_listings",
+          "columnsFrom": [
+            "listing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auction_listing_history_id_unique": {
+          "name": "auction_listing_history_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auctions": {
+      "name": "auctions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auctions_created_by_id_users_id_fk": {
+          "name": "auctions_created_by_id_users_id_fk",
+          "tableFrom": "auctions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auctions_id_unique": {
+          "name": "auctions_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "auction_webhook_url": {
+          "name": "auction_webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "system_settings_id_unique": {
+          "name": "system_settings_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_webhooks": {
+      "name": "user_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'discord'"
+        },
+        "webhook": {
+          "name": "webhook",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_webhooks_user_id_users_id_fk": {
+          "name": "user_webhooks_user_id_users_id_fk",
+          "tableFrom": "user_webhooks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_webhooks_id_unique": {
+          "name": "user_webhooks_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/lib/server/db/migrations/meta/20250204170946_snapshot.json
+++ b/src/lib/server/db/migrations/meta/20250204170946_snapshot.json
@@ -1,0 +1,847 @@
+{
+  "id": "7b7e90e2-ae4b-4ee1-b070-791e2bca248f",
+  "prevId": "bdef37f0-8eea-4502-81b5-ac687ec16ebe",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "combine_id": {
+          "name": "combine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "join_date": {
+          "name": "join_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'patron'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned_reason": {
+          "name": "banned_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires": {
+          "name": "refresh_token_expires",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_id_unique": {
+          "name": "users_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        },
+        "users_name_unique": {
+          "name": "users_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "users_combine_id_unique": {
+          "name": "users_combine_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "combine_id"
+          ]
+        },
+        "users_discord_id_unique": {
+          "name": "users_discord_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entities": {
+      "name": "entities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uid": {
+          "name": "uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_link": {
+          "name": "api_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "entities_id_unique": {
+          "name": "entities_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        },
+        "entities_uid_unique": {
+          "name": "entities_uid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "uid"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.assets": {
+      "name": "assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "combine_id": {
+          "name": "combine_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_image_url": {
+          "name": "custom_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "assets_id_unique": {
+          "name": "assets_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset_ledger": {
+      "name": "asset_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time": {
+          "name": "time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "asset_ledger_asset_id_assets_id_fk": {
+          "name": "asset_ledger_asset_id_assets_id_fk",
+          "tableFrom": "asset_ledger",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "asset_ledger_id_unique": {
+          "name": "asset_ledger_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auction_listings": {
+      "name": "auction_listings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "listing_number": {
+          "name": "listing_number",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "listed_by_id": {
+          "name": "listed_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starting_price": {
+          "name": "starting_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchased_by_id": {
+          "name": "purchased_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purchased_price": {
+          "name": "purchased_price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_credits_to_id": {
+          "name": "sent_credits_to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lister_is_anon": {
+          "name": "lister_is_anon",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "auction_id": {
+          "name": "auction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auction_listings_listed_by_id_users_id_fk": {
+          "name": "auction_listings_listed_by_id_users_id_fk",
+          "tableFrom": "auction_listings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "listed_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "auction_listings_purchased_by_id_users_id_fk": {
+          "name": "auction_listings_purchased_by_id_users_id_fk",
+          "tableFrom": "auction_listings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "purchased_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "auction_listings_auction_id_auctions_id_fk": {
+          "name": "auction_listings_auction_id_auctions_id_fk",
+          "tableFrom": "auction_listings",
+          "tableTo": "auctions",
+          "columnsFrom": [
+            "auction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auction_listings_id_unique": {
+          "name": "auction_listings_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auction_listing_items": {
+      "name": "auction_listing_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "listing_id": {
+          "name": "listing_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uuu": {
+          "name": "uuu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "custom_item": {
+          "name": "custom_item",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "custom_image_url": {
+          "name": "custom_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_item_name": {
+          "name": "custom_item_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unique_item": {
+          "name": "unique_item",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auction_listing_items_listing_id_auction_listings_id_fk": {
+          "name": "auction_listing_items_listing_id_auction_listings_id_fk",
+          "tableFrom": "auction_listing_items",
+          "tableTo": "auction_listings",
+          "columnsFrom": [
+            "listing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "auction_listing_items_asset_id_assets_id_fk": {
+          "name": "auction_listing_items_asset_id_assets_id_fk",
+          "tableFrom": "auction_listing_items",
+          "tableTo": "assets",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auction_listing_items_id_unique": {
+          "name": "auction_listing_items_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auction_listing_history": {
+      "name": "auction_listing_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "listing_id": {
+          "name": "listing_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auction_listing_history_listing_id_auction_listings_id_fk": {
+          "name": "auction_listing_history_listing_id_auction_listings_id_fk",
+          "tableFrom": "auction_listing_history",
+          "tableTo": "auction_listings",
+          "columnsFrom": [
+            "listing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auction_listing_history_id_unique": {
+          "name": "auction_listing_history_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auctions": {
+      "name": "auctions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auctions_created_by_id_users_id_fk": {
+          "name": "auctions_created_by_id_users_id_fk",
+          "tableFrom": "auctions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auctions_id_unique": {
+          "name": "auctions_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.system_settings": {
+      "name": "system_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "auction_webhook_url": {
+          "name": "auction_webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "system_settings_id_unique": {
+          "name": "system_settings_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_webhooks": {
+      "name": "user_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'discord'"
+        },
+        "webhook": {
+          "name": "webhook",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used": {
+          "name": "last_used",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_webhooks_user_id_users_id_fk": {
+          "name": "user_webhooks_user_id_users_id_fk",
+          "tableFrom": "user_webhooks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_webhooks_id_unique": {
+          "name": "user_webhooks_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/lib/server/db/migrations/meta/_journal.json
+++ b/src/lib/server/db/migrations/meta/_journal.json
@@ -106,6 +106,20 @@
       "when": 1738320318466,
       "tag": "20250131104518_married_the_fury",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1738686272399,
+      "tag": "20250204162432_silent_juggernaut",
+      "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1738688986678,
+      "tag": "20250204170946_parallel_thunderbird",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/server/db/schema/index.ts
+++ b/src/lib/server/db/schema/index.ts
@@ -7,3 +7,4 @@ export * from './auction-listing-items';
 export * from './auction-listing-history';
 export * from './auctions';
 export * from './system-settings';
+export * from './user-webhooks';

--- a/src/lib/server/db/schema/user-webhooks.ts
+++ b/src/lib/server/db/schema/user-webhooks.ts
@@ -1,0 +1,18 @@
+import { createId } from '@paralleldrive/cuid2';
+import { pgTable, text } from 'drizzle-orm/pg-core';
+import { users } from './users';
+
+export const userWebhooks = pgTable('user_webhooks', {
+	id: text('id')
+		.primaryKey()
+		.unique()
+		.$defaultFn(() => createId()),
+	userId: text('user_id')
+		.notNull()
+		.references(() => users.id),
+	name: text('name').notNull(),
+	type: text('type', { enum: ['discord'] })
+		.notNull()
+		.default('discord'),
+	webhook: text('webhook').notNull()
+});

--- a/src/lib/server/db/schema/user-webhooks.ts
+++ b/src/lib/server/db/schema/user-webhooks.ts
@@ -1,6 +1,7 @@
 import { createId } from '@paralleldrive/cuid2';
-import { pgTable, text } from 'drizzle-orm/pg-core';
+import { integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
 import { users } from './users';
+import { relations } from 'drizzle-orm';
 
 export const userWebhooks = pgTable('user_webhooks', {
 	id: text('id')
@@ -14,5 +15,22 @@ export const userWebhooks = pgTable('user_webhooks', {
 	type: text('type', { enum: ['discord'] })
 		.notNull()
 		.default('discord'),
-	webhook: text('webhook').notNull()
+	webhook: text('webhook').notNull(),
+	events: text('events').array().notNull(),
+	createdAt: timestamp('created_at')
+		.notNull()
+		.$defaultFn(() => new Date()),
+	lastUsed: timestamp('last_used')
+		.notNull()
+		.$defaultFn(() => new Date())
+		.$onUpdateFn(() => new Date()),
+	successCount: integer('success_count').default(0),
+	failureCount: integer('failure_count').default(0)
 });
+
+export const userWebhookRelations = relations(userWebhooks, ({ one }) => ({
+	user: one(users, {
+		fields: [userWebhooks.userId],
+		references: [users.id]
+	})
+}));

--- a/src/lib/server/db/schema/users.ts
+++ b/src/lib/server/db/schema/users.ts
@@ -2,6 +2,8 @@ import { createId } from '@paralleldrive/cuid2';
 import { Roles } from '../../../consts/roles';
 import { bigint, boolean, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
 import { CombineScopes } from '../../../consts/combine-scopes';
+import { relations } from 'drizzle-orm';
+import { userWebhooks } from './user-webhooks';
 
 /**
  * Represents a user in the system.
@@ -25,3 +27,7 @@ export const users = pgTable('users', {
 	refreshToken: text('refreshToken'),
 	refreshTokenExpires: bigint('refresh_token_expires', { mode: 'number' })
 });
+
+export const userRelations = relations(users, ({ many }) => ({
+	webhooks: many(userWebhooks)
+}));

--- a/src/routes/(app)/account/+page.server.ts
+++ b/src/routes/(app)/account/+page.server.ts
@@ -1,9 +1,18 @@
+import { userHooksSchema } from '$lib/models/zod/users/user-hooks.schema.js';
 import { db } from '$lib/server/db/index.js';
+import { userWebhooks } from '$lib/server/db/schema/user-webhooks.js';
 import { error } from '@sveltejs/kit';
+import { and, eq, getTableColumns } from 'drizzle-orm';
+import { fail, message, superValidate } from 'sveltekit-superforms';
+import { zod } from 'sveltekit-superforms/adapters';
 
-export const load = async ({ locals }) => {
+export const load = async ({ locals, depends }) => {
+	depends('account');
 	const record = await db.query.users.findFirst({
-		where: (r, { eq }) => eq(r.id, locals.user.id)
+		where: (r, { eq }) => eq(r.id, locals.user.id),
+		with: {
+			webhooks: true
+		}
 	});
 
 	if (!record) {
@@ -11,6 +20,55 @@ export const load = async ({ locals }) => {
 	}
 
 	return {
-		record: record
+		record: record,
+		form: await superValidate(zod(userHooksSchema))
 	};
+};
+
+export const actions = {
+	registerHook: async ({ locals, request }) => {
+		const form = await superValidate(request, zod(userHooksSchema));
+
+		if (!form.valid) {
+			return fail(400, { form });
+		}
+
+		console.log(form.data);
+
+		if (!form.data.webhook.includes('discord')) {
+			return fail(400, { form, message: 'Webhook must be a Discord URL' });
+		}
+
+		const hook = await db
+			.insert(userWebhooks)
+			.values({
+				userId: locals.user.id,
+				events: form.data.events,
+				type: form.data.type,
+				webhook: form.data.webhook,
+				name: form.data.name
+			})
+			.returning({ ...getTableColumns(userWebhooks) });
+
+		return { form, message: `Hook ${hook[0].id} registered` };
+	},
+
+	deleteHook: async ({ locals, request }) => {
+		const formData = await request.formData();
+
+		console.log(formData);
+
+		const record = await db.query.userWebhooks.findFirst({
+			where: (r, { eq, and }) =>
+				and(eq(r.id, formData.get('id') as string), eq(r.userId, locals.user.id))
+		});
+
+		if (!record) {
+			return fail(404, { message: 'Hook not found' });
+		}
+
+		await db
+			.delete(userWebhooks)
+			.where(and(eq(userWebhooks.id, record.id), eq(userWebhooks.userId, locals.user.id)));
+	}
 };

--- a/src/routes/(app)/account/+page.server.ts
+++ b/src/routes/(app)/account/+page.server.ts
@@ -56,8 +56,6 @@ export const actions = {
 	deleteHook: async ({ locals, request }) => {
 		const formData = await request.formData();
 
-		console.log(formData);
-
 		const record = await db.query.userWebhooks.findFirst({
 			where: (r, { eq, and }) =>
 				and(eq(r.id, formData.get('id') as string), eq(r.userId, locals.user.id))

--- a/src/routes/(app)/account/+page.svelte
+++ b/src/routes/(app)/account/+page.svelte
@@ -3,16 +3,65 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
 	import * as Avatar from '$lib/components/ui/avatar';
+	import * as Tabs from '$lib/components/ui/tabs';
+	import * as Dialog from '$lib/components/ui/dialog/index.js';
+	import * as Form from '$lib/components/ui/form/index.js';
+	import * as AlertDialog from '$lib/components/ui/alert-dialog/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
 	import { format } from 'date-fns';
 	import { Separator } from '$lib/components/ui/separator/index.js';
 	import { Switch } from '$lib/components/ui/switch/index.js';
+	import { onMount } from 'svelte';
+	import { page } from '$app/state';
+	import PageWrapper from '$lib/components/custom/layout/page-wrapper.svelte';
+	import SuperDebug, { superForm } from 'sveltekit-superforms';
+	import { zodClient } from 'sveltekit-superforms/adapters';
+	import { userHooksSchema } from '$lib/models/zod/users/user-hooks.schema.js';
+	import { WebhookEvent } from '$lib/consts/webhook-event.js';
+	import { Checkbox } from '$lib/components/ui/checkbox/index.js';
+	import { toast } from 'svelte-sonner';
+	import UserWebhookCard from '$lib/components/custom/account/user-webhook-card.svelte';
 
 	let { data } = $props();
-
 	let record = $derived(data.record);
+	let selectedTab = $state('combine');
+	let registerHookDialogOpen = $state(false);
+
+	const form = superForm(data.form, {
+		validators: zodClient(userHooksSchema),
+		dataType: 'json',
+		onResult: ({ result }) => {
+			console.log(result);
+			switch (result.type) {
+				case 'success':
+					registerHookDialogOpen = false;
+					toast(result.data?.message);
+					break;
+				case 'failure':
+					toast.error(result.data?.message ?? 'An error occurred while registering the hook.');
+					break;
+			}
+		}
+	});
+
+	const { form: formData, enhance } = form;
+
+	onMount(() => {
+		const tab = page.url.searchParams.get('tab');
+
+		if (tab) {
+			selectedTab = tab;
+		}
+
+		const registerHook = page.url.searchParams.get('registerHook');
+
+		if (registerHook) {
+			registerHookDialogOpen = true;
+		}
+	});
 </script>
 
-<LayoutWrapper title="Account">
+<PageWrapper title="Account">
 	<Card.Root>
 		<Card.Header>
 			<Card.Title>
@@ -45,34 +94,147 @@
 				</div>
 			</div>
 
-			<div class="mt-4">
-				<div class="flex flex-col gap-3">
-					<Separator class="bg-primary" />
-					<h3>Granted Scopes</h3>
+			<div class="mt-3">
+				<Tabs.Root bind:value={selectedTab}>
+					<Tabs.TabsList>
+						<Tabs.Trigger value="combine">Combine Sync</Tabs.Trigger>
+						<Tabs.Trigger value="hooks">Webhooks</Tabs.Trigger>
+					</Tabs.TabsList>
 
-					<div class="flex flex-row items-center justify-between rounded-md border p-2">
-						<div class="flex flex-col">
-							<h4 class="text-primary">Character Read</h4>
-							<p>This is required to be able to login.</p>
+					<Tabs.Content value="combine">
+						<div class="mt-4">
+							<div class="flex flex-col gap-3">
+								<Separator class="bg-primary" />
+								<h3>Granted Scopes</h3>
+
+								<div class="flex flex-row items-center justify-between rounded-md border p-2">
+									<div class="flex flex-col">
+										<div class="mb-3 flex flex-col">
+											<h4 class="text-primary">Character - Read</h4>
+											<p class="text-xs text-muted-foreground">character_read</p>
+										</div>
+										<p class="text-sm">This is required to be able to login.</p>
+									</div>
+
+									<Switch checked class="data-[state=checked]:bg-green-600" disabled />
+								</div>
+
+								<div class="flex flex-row items-center justify-between rounded-md border p-2">
+									<div class="flex flex-col">
+										<div class="mb-3 flex flex-col">
+											<h4 class="text-primary">Personal Inventory Overview</h4>
+											<p class="text-xs text-muted-foreground">personal_inv_ships</p>
+										</div>
+										<p class="text-sm">
+											We use this to help you list assets from your inventory to sell on the market.
+											We do not store your inventory data and is pulled on demand.
+										</p>
+										<p class="text-red-500">Not Implemented Yet</p>
+									</div>
+
+									<Switch class="data-[state=checked]:bg-green-600" disabled />
+								</div>
+							</div>
 						</div>
+					</Tabs.Content>
 
-						<Switch checked class="data-[state=checked]:bg-green-600" disabled />
-					</div>
+					<Tabs.Content value="hooks">
+						<div class="mt-4">
+							<div class="flex flex-col gap-3">
+								<Separator class="bg-primary" />
+								<div class="flex items-center justify-between">
+									<h3>Webhooks</h3>
+									<Dialog.Root bind:open={registerHookDialogOpen}>
+										<Dialog.Trigger>
+											<Button size="sm" variant="action">Register Hook</Button>
+										</Dialog.Trigger>
+										<Dialog.Content>
+											<Dialog.Header>
+												<Dialog.Title>Register Hook</Dialog.Title>
+												<Dialog.Description>
+													Register a new webhook subscription.
+												</Dialog.Description>
+											</Dialog.Header>
 
-					<div class="flex flex-row items-center justify-between rounded-md border p-2">
-						<div class="flex flex-col">
-							<h4 class="text-primary">Personal Inventory Overview</h4>
-							<p>
-								We use this to help you list assets from your inventory to sell on the market. We do
-								not store your inventory data and is pulled on demand.
-							</p>
-							<p class="text-red-500">Not Implemented Yet</p>
+											<form method="POST" action="?/registerHook" use:enhance>
+												<Form.Field {form} name="name">
+													<Form.Control>
+														{#snippet children({ props })}
+															<Form.Label>Name</Form.Label>
+															<Input {...props} bind:value={$formData.name} />
+														{/snippet}
+													</Form.Control>
+													<Form.Description>
+														An easily identifiable name for your hook
+													</Form.Description>
+													<Form.FieldErrors />
+												</Form.Field>
+
+												<Form.Field {form} name="webhook">
+													<Form.Control>
+														{#snippet children({ props })}
+															<Form.Label>Webhook</Form.Label>
+															<Input
+																{...props}
+																class="overflow-hidden"
+																bind:value={$formData.webhook}
+															/>
+														{/snippet}
+													</Form.Control>
+													<Form.Description>The URL of your webhook.</Form.Description>
+													<Form.FieldErrors />
+												</Form.Field>
+
+												<Form.Field {form} name="events">
+													{#each WebhookEvent as event}
+														{@const checked = $formData.events.includes(event)}
+														<div class="flex flex-row items-center gap-3">
+															<Form.Control>
+																{#snippet children({ props })}
+																	<Checkbox
+																		{...props}
+																		{checked}
+																		value={event}
+																		onCheckedChange={(v) => {
+																			if (v) {
+																				$formData.events = [...$formData.events, event];
+																			} else {
+																				$formData.events = $formData.events.filter(
+																					(e) => e !== event
+																				);
+																			}
+																		}}
+																	/>
+
+																	<Form.Label class="font-normal">{event}</Form.Label>
+																{/snippet}
+															</Form.Control>
+														</div>
+													{/each}
+												</Form.Field>
+
+												<div class="flex justify-end">
+													<Form.Button size="sm" variant="action">Register Hook</Form.Button>
+												</div>
+											</form>
+										</Dialog.Content>
+									</Dialog.Root>
+								</div>
+								<p>
+									Webhook subscriptions allow you to subscribe to certain events that happen on the
+									holochain. Please note, as of right now, the holochain
+									<span class="text-primary">only supports Discord</span>
+									webhooks.
+								</p>
+
+								{#each record?.webhooks as hook}
+									<UserWebhookCard action="?/deleteHook" {hook} depends={'account'} />
+								{/each}
+							</div>
 						</div>
-
-						<Switch class="data-[state=checked]:bg-green-600" disabled />
-					</div>
-				</div>
+					</Tabs.Content>
+				</Tabs.Root>
 			</div>
 		</Card.Content>
 	</Card.Root>
-</LayoutWrapper>
+</PageWrapper>

--- a/src/routes/(public)/p/+layout.svelte
+++ b/src/routes/(public)/p/+layout.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	let { children } = props;
+</script>
+
+{@render children()}

--- a/src/routes/api/auctions/listings/[id]/+server.ts
+++ b/src/routes/api/auctions/listings/[id]/+server.ts
@@ -1,4 +1,5 @@
 import { MagistratePermissionPolicy } from '$lib/consts/permission-policies.js';
+import { onNewAuctionListingHook } from '$lib/hooks/server/auctions/new-listing.hook.js';
 import type { PublishListingRequest } from '$lib/models/auctions/publish-listing.req.js';
 import { publishListingSchema } from '$lib/models/zod/auctions/listings/publish-listing.schema.js';
 import { db } from '$lib/server/db/index.js';
@@ -152,6 +153,8 @@ export const POST = async ({ locals, params, request }) => {
 			}
 		}
 	});
+
+	await onNewAuctionListingHook(record.id);
 
 	return json({
 		status: 200,

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -33,6 +33,9 @@ const config: Config = {
 					DEFAULT: 'hsl(var(--destructive) / <alpha-value>)',
 					foreground: 'hsl(var(--destructive-foreground) / <alpha-value>)'
 				},
+				danger: {
+					DEFAULT: 'hsl(var(--danger))'
+				},
 				muted: {
 					DEFAULT: 'hsl(var(--muted) / <alpha-value>)',
 					foreground: 'hsl(var(--muted-foreground) / <alpha-value>)'


### PR DESCRIPTION
# Summary of Changes

Users can now create their own discord webhook subscriptions for their servers. Right now, it only supports discord and only supports when a listing is published.

# Type of Changes

- [x] feat
- [ ] bug fix
- [ ] chore
- [ ] breaking change
    